### PR TITLE
Add Dependabot updates and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## What changed

- Added `.github/dependabot.yml` with two ecosystems:
  - `gradle` at the repository root, which covers the subprojects reached through `settings.gradle.kts` and `gradle/libs.versions.toml`
  - `github-actions` at the repository root, which covers `ci.yml` and `pages.yml`
- Added `.github/CODEOWNERS` with `* @yuyuyuyuyu-dev`

## Why

Dependency and action versions were only ever bumped by hand. Dependabot now opens those pull requests instead.

Both ecosystems are set to `interval: daily` so updates arrive quickly, and `open-pull-requests-limit: 1` keeps only one open pull request per ecosystem at a time, so a daily schedule does not turn into a pile of pull requests waiting for review.

The repository had no CODEOWNERS file, so one is added to put a review request on the pull requests Dependabot opens.

## Notes for the reviewer

- No npm ecosystem entry. The `package.json` files under `webApp/` and `shared/` are generated by Gradle into `build/` and are not checked in.
- Dependabot's `gradle` ecosystem does not update the Gradle wrapper, so `gradle/wrapper/gradle-wrapper.properties` still needs a manual bump.
- The first run may open two pull requests at once, one per ecosystem. The limit of 1 applies per ecosystem, not across the whole repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)