### PR TITLE
Use the material3 version constant from the Compose Multiplatform plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ kotlin = "2.4.10"
 kotlin-wrappers = "2026.7.2"
 kotlinx-coroutines = "1.11.0"
 ktlint = "14.2.0"
-material3 = "1.11.0-alpha07"
 versionCatalogUpdate = "1.1.1"
 
 [libraries]
@@ -16,7 +15,6 @@ androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.compose.ComposeBuildConfig
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -22,7 +23,9 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
-            implementation(libs.compose.material3)
+            // material3 is versioned separately from the rest of Compose Multiplatform,
+            // so the version the plugin was built against is the one to use
+            implementation("org.jetbrains.compose.material3:material3:${ComposeBuildConfig.composeMaterial3Version}")
             implementation(libs.compose.ui)
             implementation(libs.compose.components.resources)
             implementation(libs.compose.uiToolingPreview)


### PR DESCRIPTION
## What changed

- Removed the `material3` version and the `compose-material3` library entry from `gradle/libs.versions.toml`.
- `shared/build.gradle.kts` now declares material3 with the version constant the Compose Multiplatform plugin exposes:

  ```kotlin
  implementation("org.jetbrains.compose.material3:material3:${ComposeBuildConfig.composeMaterial3Version}")
  ```

## Why

material3 is versioned separately from the rest of Compose Multiplatform, so the catalog had to pin it by hand and keep it in step with the plugin on its own. The plugin already ships the version it was built against, and the `compose.material3` accessor is deprecated in 1.11.1 in favour of exactly this form, so taking the version from the plugin removes the manual pin.

## Notes for reviewers

- The resolved version moves from `1.11.0-alpha07` to `1.9.0`, the stable release that Compose Multiplatform 1.11.1 was built against. Every material3 API used in the app (`Button`, `Card`, `Scaffold`, `Slider`, `Switch`, `OutlinedTextField`, `lightColorScheme`, and the snackbar types) is stable, so nothing in the app depends on the alpha.
- Because material3 is no longer in the catalog, Dependabot will stop opening update PRs for it. That is intended: the version now follows `composeMultiplatform`, which Dependabot still tracks.
- `:shared:compileKotlinJvm`, `ktlintCheck`, `detekt` and `allTests` all pass, and `versionCatalogFormat` leaves the catalog unchanged, so the version catalog CI job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)