### PR TITLE
Group and auto-merge minor and patch Dependabot updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,23 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: "dependabot-auto-merge-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  metadata:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      update-type: ${{ steps.metadata.outputs.update-type }}
+    steps:
+      - name: Fetch the Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+
+  auto-merge:
+    needs: metadata
+    if: >-
+      needs.metadata.outputs.update-type == 'version-update:semver-minor' ||
+      needs.metadata.outputs.update-type == 'version-update:semver-patch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.AUTO_MERGE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Dependabot opens one pull request per dependency, so a stream of small version bumps needs the same manual attention as a real change. This groups the harmless ones together and lets them merge on their own.

## What changed

Minor and patch updates are now grouped into a single pull request per ecosystem. Major updates keep getting their own pull request, so a breaking change is still reviewed on its own.

A new workflow enables auto-merge with squash on Dependabot pull requests whose highest update is minor or patch. It reads the update type with `dependabot/fetch-metadata` and merges through a GitHub App token, because the token Dependabot gives a workflow is read only. Auto-merge only queues the merge, so the required checks on `main` still have to pass first, and a major update is never merged this way.

`CODEOWNERS` is removed. It only auto-requested a review from the sole owner of the repository, and no rule required that review.

## Repository setup

This needs settings that live outside the repository, and they are already in place:

- `Allow auto-merge` is enabled.
- A GitHub App with `Contents: write`, `Pull requests: write` and `Workflows: write` is installed. The workflows permission is needed because updates to actions change files under `.github/workflows`.
- `AUTO_MERGE_APP_CLIENT_ID` and `AUTO_MERGE_APP_PRIVATE_KEY` are stored as Dependabot secrets rather than Actions secrets, since a workflow triggered by a Dependabot pull request can only read the former.

`open-pull-requests-limit` stays at 1 on purpose. `main` requires a branch to be up to date before merging, so a second open pull request would always need a rebase.
